### PR TITLE
Makefile.rules: fix wrong target dependency

### DIFF
--- a/src/Makefile.rules
+++ b/src/Makefile.rules
@@ -111,8 +111,8 @@ u32-selectrange: u32-selectrange.o binio.o
 u32-to-sd: u32-to-sd.o binio.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
-u32-mcv: u32-mcv.o binio.o -lm
-	$(CC) -o $@ $^ $(LDFLAGS)
+u32-mcv: u32-mcv.o binio.o
+	$(CC) -o $@ $^ $(LDFLAGS) -lm
 
 u32-counter-endian: u32-counter-endian.o binio.o binutil.o
 	$(CC) -o $@ $^ $(LDFLAGS)


### PR DESCRIPTION
Wrong dependency causes ld to scream at me like 

```
/usr/bin/ld: /lib/libm.so: error adding symbols: file in wrong format
collect2: error: ld returned 1 exit status
```

So removed wrong dependency and put -lm on a next line where it belongs to be